### PR TITLE
Update feature for blog

### DIFF
--- a/TabloidCLI/Repositories/BlogRepository.cs
+++ b/TabloidCLI/Repositories/BlogRepository.cs
@@ -69,6 +69,29 @@ namespace TabloidCLI.Repositories
             }
         }
 
+        public void Update(Blog blog)
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"UPDATE Blog
+                                        SET Title = @title,
+                                             URL = @url
+                                             WHERE Id = @id";
+                    cmd.Parameters.AddWithValue("@title", blog.Title);
+                    cmd.Parameters.AddWithValue("@url", blog.Url);
+                    cmd.Parameters.AddWithValue("@id", blog.Id);
+
+                    cmd.ExecuteNonQuery();
+
+                }
+            }
+        }
+
+
         public void Delete(int id)
         {
             using(SqlConnection conn = Connection)

--- a/TabloidCLI/UserInterfaceManagers/BlogManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/BlogManager.cs
@@ -48,8 +48,7 @@ namespace TabloidCLI.UserInterfaceManagers
                     Console.WriteLine();
                     return this;
                 case "4":
-                    Console.WriteLine("We're sorry, that function is unavailable");
-                    Console.WriteLine("Please make another selection");
+                    Edit();
                     Console.WriteLine();
                     return this;
                 case "5":
@@ -123,6 +122,36 @@ namespace TabloidCLI.UserInterfaceManagers
                 Url = url
             };
             _blogRepository.Insert(blog);
+        }
+
+        private void Edit()
+        {
+            Blog blogToEdit = Choose("What blog would you like to update?");
+
+            if(blogToEdit == null)
+            {
+                return;
+            }
+
+            Console.WriteLine($"Current Title: {blogToEdit.Title}");
+            Console.WriteLine("What would you like to update the title to?");
+            Console.WriteLine(">");
+            string title = Console.ReadLine();
+            if(!String.IsNullOrWhiteSpace(title))
+            {
+                blogToEdit.Title = title;
+            }
+
+            Console.WriteLine("Please type the new URL");
+            Console.WriteLine(">");
+            string url = Console.ReadLine();
+            if(!String.IsNullOrWhiteSpace(url))
+            {
+                blogToEdit.Url = url;
+            }
+
+            _blogRepository.Update(blogToEdit);
+            
         }
 
         private void Remove()


### PR DESCRIPTION
Blog menu now has the option to edit an existing blog. 

To test:
Run TabloidCLI, choose 2 from menu to go into the blog options
Choose 4 to edit an existing blog
Screen should show all current blogs, it will then ask you to make a selection
It should then show your choice's title and ask you to edit (pressing enter without entering anything will continue with current title)
Then it will show your current URL for the blog, you may enter a new URL or hit enter to continue with current URL.
Once you're done, hit 1 on the blog menu and you should see your updated blog in the list